### PR TITLE
Couple of small improvements to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,11 +37,12 @@ in pkgs.mkShell {
     export WAYLAND_PROTOCOLS=${pkgs.wayland-protocols}/share/wayland-protocols
     export WAYLAND_SCANNER=${pkgs.wayland-scanner}/bin/wayland-scanner
     export WLR_RENDERER=pixman
-    
+    unset GHC_PACKAGE_PATH
+
     # Build tinywl
     echo "Building tinywl..."
     cd tinywl
-    make clean
+    make -f Makefile.shared clean
     make -f Makefile.shared
     cd ..
     


### PR DESCRIPTION
GHC_PACKAGE_PATH is usually set for me. Saves me just a small bit of hassle to unset it in the nix shell hook.

The point of the `make clean` change should be obvious :)