### PR TITLE
refactor of tinywl and code addition for keybindings

### DIFF
--- a/tinywl/Makefile.shared
+++ b/tinywl/Makefile.shared
@@ -6,7 +6,7 @@ LIBS=\
 	 $(shell pkg-config --cflags --libs xkbcommon)
 
 # Add -fPIC for position-independent code
-CFLAGS += -fPIC
+CFLAGS += -fPIC -g -ggdb -O1
 
 # Output file is now a shared library
 OUTPUT = libtinywl.so

--- a/tinywl/tinywl.h
+++ b/tinywl/tinywl.h
@@ -1,36 +1,36 @@
 #ifndef TINYWL_H
 #define TINYWL_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <xkbcommon/xkbcommon.h>
 
-// Forward declarations for opaque pointers
-struct wl_display;
+typedef void (*keybinding_handler_t)(xkb_keysym_t sym);
+
+
+
+static uint32_t global_modifier = WLR_MODIFIER_LOGO; // Default
+
+void set_modifier_key(uint32_t modifier) {
+    global_modifier = modifier;
+}
+
+
+
+// Forward declarations for opaque types
 struct wlr_backend;
 struct wlr_renderer;
 struct wlr_allocator;
 struct wlr_scene;
 struct wlr_scene_output_layout;
-struct wlr_xdg_shell;
 struct wlr_cursor;
 struct wlr_xcursor_manager;
 struct wlr_seat;
-struct tinywl_toplevel;
-struct wlr_output_layout;
-
-// Define structures that were causing "incomplete type" errors
-struct wl_listener {
-    void *notify;
-};
-
-struct wl_list {
-    void *prev;
-    void *next;
-};
-
-struct wlr_box {
-    int x, y;
-    int width, height;
-};
+struct wlr_box;
 
 enum tinywl_cursor_mode {
     TINYWL_CURSOR_PASSTHROUGH,
@@ -72,6 +72,54 @@ struct tinywl_server {
     struct wlr_output_layout *output_layout;
     struct wl_list outputs;
     struct wl_listener new_output;
+  keybinding_handler_t keybinding_handler;
+
+
 };
+
+struct tinywl_output {
+    struct wl_list link;
+    struct tinywl_server *server;
+    struct wlr_output *wlr_output;
+    struct wl_listener frame;
+    struct wl_listener request_state;
+    struct wl_listener destroy;
+};
+
+struct tinywl_toplevel {
+    struct wl_list link;
+    struct tinywl_server *server;
+    struct wlr_xdg_toplevel *xdg_toplevel;
+    struct wlr_scene_tree *scene_tree;
+    struct wl_listener map;
+    struct wl_listener unmap;
+    struct wl_listener destroy;
+    struct wl_listener request_move;
+    struct wl_listener request_resize;
+    struct wl_listener request_maximize;
+    struct wl_listener request_fullscreen;
+};
+
+struct tinywl_keyboard {
+    struct wl_list link;
+    struct tinywl_server *server;
+    struct wlr_keyboard *wlr_keyboard;
+    struct wl_listener modifiers;
+    struct wl_listener key;
+    struct wl_listener destroy;
+};
+
+// Server lifecycle functions
+struct tinywl_server *server_create(void);
+void server_destroy(struct tinywl_server *server);
+bool server_init(struct tinywl_server *server);
+const char *server_start(struct tinywl_server *server);
+void server_run(struct tinywl_server *server);
+void server_set_startup_command(const char *cmd);
+
+
+
+// Key handling functions
+void set_haskell_key_notification_function(void (*func)(xkb_keysym_t sym));
 
 #endif // TINYWL_H


### PR DESCRIPTION
refactor of tinywl to divide between source and header to make it easier. 

Addition of some code to enable the keybindings feature.