### PR TITLE
Allow configuration in Main

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -42,6 +42,12 @@ startingApps = do
           ("swaybg", ["-i", "./images/haskell.png", "-m", "fill"])
         ]
 
+cycleWindows :: State -> IO Bool
+cycleWindows state = FFI.c_cycle_windows $ server state
+
+terminate :: State -> IO ()
+terminate state = FFI.c_wl_display_terminate $ display state
+
 customKeybindings
     :: State -> Config -> IO (FunPtr (CUInt -> IO ()))
 customKeybindings state config = do
@@ -96,7 +102,7 @@ customKeybindings state config = do
                 -- the key Events just show up here as ints so you can also match against a raw int
                 wlr_log WLR_INFO "Mod + c pressed closing server"
                 -- for this event we call a Wayland FFI function
-                FFI.c_wl_display_terminate $ display state
+                terminate state
                 pure ()
             when
                 ( sym == keySymToInt KEY_d || sym == keySymToInt KEY_v || sym == keySymToInt KEY_l
@@ -104,7 +110,7 @@ customKeybindings state config = do
                 $ do
                     -- You can also use logical OR
                     wlr_log WLR_INFO "Mod + d pressed, cycling windows"
-                    result <- FFI.c_cycle_windows $ server state
+                    result <- cycleWindows state
                     ( if result
                             then wlr_log WLR_INFO "window cycled"
                             else wlr_log WLR_INFO "Window cycling failed, Only one window"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -132,7 +132,7 @@ runWLHS config = do
                             setEnv "WAYLAND_DISPLAY" socketStr
                             wlr_log WLR_INFO $ "WAYLAND_DISPLAY set to " ++ socketStr
                             withCString (startupApplication config) FFI.c_server_set_startup_command
-                            setModKey ModAlt
+                            setModKey $ modKey config
                             handlerPtr <- customKeybindings wlDisplay server config
                             wlr_log WLR_DEBUG $ "Handler created: " ++ show handlerPtr
                             FFI.c_set_keybinding_handler server handlerPtr

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,16 +1,13 @@
 module Config where
 
-import Control.Monad (when)
 import Foreign
 import Foreign.C (CUInt)
 import Foreign.C.String
 import System.Environment (getArgs, setEnv)
-import System.Process (spawnProcess)
 
 import qualified LibTinyWLHS.Compositor.Compositor as Compositor
 import LibTinyWLHS.Compositor.Types
 import LibTinyWLHS.KeyBinding.KeyBindings
-import LibTinyWLHS.KeyBinding.KeySyms
 import qualified LibTinyWLHS.Server.FFI as FFI
 import qualified LibTinyWLHS.Server.Server as Server
 import LibTinyWLHS.Server.Types (TinyWLServer)
@@ -21,10 +18,10 @@ import WLR.Util.Log
 
 data Config = Config
     { logLevel :: WLR_log_importance
-    , startupApplication :: String
-    , onStartup :: IO ()
     , modKey :: Modifier
-    , terminalEmulator :: String
+    , onStartup :: IO ()
+    , onKeyPress :: State -> CUInt -> IO ()
+    , startupApplication :: String
     }
 
 data State = State
@@ -41,74 +38,7 @@ terminate state = FFI.c_wl_display_terminate $ display state
 customKeybindings
     :: State -> Config -> IO (FunPtr (CUInt -> IO ()))
 customKeybindings state config = do
-    let
-        handler :: CUInt -> IO ()
-        handler sym = do
-            -- Add your custom key event handler heres
-            wlr_log WLR_INFO $ "Handler called with sym: " ++ show sym
-            when (sym == keySymToInt KEY_s) $ do
-                -- simple match to key events defined in LibTinyWL.KeyBinding.KeySyms
-                wlr_log WLR_INFO "Mod + s pressed, spawning a terminal emulator"
-                -- for this key event a process is spawned in Haskell
-                _ <- spawnProcess (terminalEmulator config) []
-                -- _ <- spawnProcess "swaybg" ["-i", "~/.wallpapers/haskell.png", "-m", "fill"]
-                pure ()
-
-            when (sym == keySymToInt KEY_a) $ do
-                -- simple match to key events defined in LibTinyWL.KeyBinding.KeySyms
-                wlr_log WLR_INFO "Mod + a pressed, running beMenu"
-                _ <-
-                    spawnProcess
-                        "bemenu-run"
-                        [ "-i" -- case insensitive
-                        , "-l"
-                        , "10" -- show 10 lines
-                        , "-p"
-                        , "run:" -- prompt
-                        , "--tb"
-                        , "#285577" -- title background
-                        , "--tf"
-                        , "#ffffff" -- title foreground
-                        , "--fb"
-                        , "#222222" -- filter background
-                        , "--ff"
-                        , "#ffffff" -- filter foreground
-                        , "--nb"
-                        , "#222222" -- normal background
-                        , "--nf"
-                        , "#888888" -- normal foreground
-                        , "--hb"
-                        , "#285577" -- highlighted background
-                        , "--hf"
-                        , "#ffffff" -- highlighted foreground
-                        , "--fn"
-                        , "monospace 12" -- font
-                        , "-W"
-                        , terminalEmulator config ++ " -e"
-                        ] -- for this key event a process is spawned in Haskell
-                pure ()
-
-            when (sym == keySymToInt KEY_c) $ do
-                -- the key Events just show up here as ints so you can also match against a raw int
-                wlr_log WLR_INFO "Mod + c pressed closing server"
-                -- for this event we call a Wayland FFI function
-                terminate state
-                pure ()
-            when
-                ( sym == keySymToInt KEY_d || sym == keySymToInt KEY_v || sym == keySymToInt KEY_l
-                )
-                $ do
-                    -- You can also use logical OR
-                    wlr_log WLR_INFO "Mod + d pressed, cycling windows"
-                    result <- cycleWindows state
-                    ( if result
-                            then wlr_log WLR_INFO "window cycled"
-                            else wlr_log WLR_INFO "Window cycling failed, Only one window"
-                        )
-
-                    pure ()
-
-    mkKeybindingHandler handler
+    mkKeybindingHandler $ (onKeyPress config) state
 
 runWLHS :: Config -> IO ()
 runWLHS config = do

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -22,6 +22,7 @@ import WLR.Util.Log
 data Config = Config
     { logLevel :: WLR_log_importance
     , startupApplication :: String
+    , onStartup :: IO ()
     , modKey :: Modifier
     , terminalEmulator :: String
     }
@@ -30,17 +31,6 @@ data State = State
     { display :: Ptr WlDisplay
     , server :: Ptr TinyWLServer
     }
-
--- Process to run on startup with the program name and an array of arguments to pass to it
-startingApps :: IO ()
-startingApps = do
-    startUpProcess
-        [ -- [ ("kitty", [])
-          -- ,
-          ("yambar", [])
-        , -- , ("wbg", ["~/.wallpapers/haskell.png"])
-          ("swaybg", ["-i", "./images/haskell.png", "-m", "fill"])
-        ]
 
 cycleWindows :: State -> IO Bool
 cycleWindows state = FFI.c_cycle_windows $ server state
@@ -147,7 +137,7 @@ runWLHS config = do
                             handlerPtr <- customKeybindings (State { display = wlDisplay, server = myServer} ) config
                             wlr_log WLR_DEBUG $ "Handler created: " ++ show handlerPtr
                             FFI.c_set_keybinding_handler myServer handlerPtr
-                            startingApps
+                            onStartup config
                             wlr_log WLR_INFO "TinyWLHS started"
                             FFI.c_server_run myServer
                         else wlr_log WLR_ERROR "Failed to start server"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,47 +1,17 @@
 module Main where
 
 import Config
-import Foreign.C.String
-import Foreign.Ptr
-import qualified LibTinyWLHS.Compositor.Compositor as Compositor
 import LibTinyWLHS.KeyBinding.KeyBindings
-import qualified LibTinyWLHS.Server.FFI as FFI
-import qualified LibTinyWLHS.Server.Server as Server
-import Setup
-import System.Environment (getArgs, setEnv)
 import WLR.Util.Log
 
+-- Customize your app here, to help I placed the options in the comments
+appConfig :: Config
+appConfig = Config
+        { logLevel = WLR_DEBUG -- WLR_INFO | WLR_DEBUG | WLR_SILENT | WLR_ERROR
+        , startupApplication = "" -- can be any app that works with wayland, Leave blank for no startup app
+        , modKey = ModAlt -- ModAlt | ModCtrl | ModLogo | ModShift
+        , terminalEmulator = "kitty" -- I use kitty as my emulator, alacritty is also a popular choice
+        }
+
 main :: IO ()
-main = do
-    wlr_log_init (logLevel appConfig) nullFunPtr
-    args <- getArgs
-    commandLineArguments args
-    setup <- setupServer
-    wlr_log WLR_INFO "Server destroyed, shutting down"
-    case setup of
-        Nothing -> wlr_log WLR_ERROR "Failed to Setup Server"
-        Just (server, renderer) -> do
-            initSuccess <- FFI.c_server_init server
-            if initSuccess
-                then do
-                    wlr_log WLR_INFO "Server initialized successfully"
-                    wlDisplay <- Server.getWlDisplay server
-                    _ <- Compositor.initialize_compositor wlDisplay 5 renderer
-                    socket <- FFI.c_server_start server
-                    if socket /= nullPtr
-                        then do
-                            socketStr <- peekCString socket
-                            setEnv "WAYLAND_DISPLAY" socketStr
-                            wlr_log WLR_INFO $ "WAYLAND_DISPLAY set to " ++ socketStr
-                            withCString (startupApplication appConfig) FFI.c_server_set_startup_command
-                            setModKey ModAlt
-                            handlerPtr <- customKeybindings wlDisplay server
-                            wlr_log WLR_DEBUG $ "Handler created: " ++ show handlerPtr
-                            FFI.c_set_keybinding_handler server handlerPtr
-                            startingApps
-                            wlr_log WLR_INFO "TinyWLHS started"
-                            FFI.c_server_run server
-                        else wlr_log WLR_ERROR "Failed to start server"
-                else wlr_log WLR_ERROR "Failed to initialize server"
-            FFI.c_server_destroy server
-            wlr_log WLR_INFO "Server destroyed, shutting down"
+main = runWLHS appConfig

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,7 +1,11 @@
 module Main where
 
+import Control.Monad (when)
+import System.Process (spawnProcess)
+
 import Config
 import LibTinyWLHS.KeyBinding.KeyBindings
+import LibTinyWLHS.KeyBinding.KeySyms
 import Setup
 import WLR.Util.Log
 
@@ -10,14 +14,76 @@ appConfig :: Config
 appConfig = Config
         { logLevel = WLR_DEBUG -- WLR_INFO | WLR_DEBUG | WLR_SILENT | WLR_ERROR
         , startupApplication = "" -- can be any app that works with wayland, Leave blank for no startup app
-        , onStartup = startApps
+        , onStartup = handleStartup
+        , onKeyPress = handleKeyPress
         , modKey = ModAlt -- ModAlt | ModCtrl | ModLogo | ModShift
-        , terminalEmulator = "kitty" -- I use kitty as my emulator, alacritty is also a popular choice
         }
-    where startApps = do startUpProcess [ ("yambar", [])
-                                        , ("swaybg", ["-i", "./images/haskell.png", "-m", "fill"])
-                                        ]
+    where
+          terminalEmulator = "kitty" -- I use kitty as my emulator, alacritty is also a popular choice
+          handleStartup = do startUpProcess [("yambar", [])
+                                            , ("swaybg", ["-i", "./images/haskell.png", "-m", "fill"])
+                                            ]
+          handleKeyPress state sym = do
+            -- Add your custom key event handler heres
+            wlr_log WLR_INFO $ "Handler called with sym: " ++ show sym
+            when (sym == keySymToInt KEY_s) $ do
+                -- simple match to key events defined in LibTinyWL.KeyBinding.KeySyms
+                wlr_log WLR_INFO "Mod + s pressed, spawning a terminal emulator"
+                -- for this key event a process is spawned in Haskell
+                _ <- spawnProcess terminalEmulator []
+                -- _ <- spawnProcess "swaybg" ["-i", "~/.wallpapers/haskell.png", "-m", "fill"]
+                pure ()
+            when (sym == keySymToInt KEY_a) $ do
+                -- simple match to key events defined in LibTinyWL.KeyBinding.KeySyms
+                wlr_log WLR_INFO "Mod + a pressed, running beMenu"
+                _ <-
+                    spawnProcess
+                        "bemenu-run"
+                        [ "-i" -- case insensitive
+                        , "-l"
+                        , "10" -- show 10 lines
+                        , "-p"
+                        , "run:" -- prompt
+                        , "--tb"
+                        , "#285577" -- title background
+                        , "--tf"
+                        , "#ffffff" -- title foreground
+                        , "--fb"
+                        , "#222222" -- filter background
+                        , "--ff"
+                        , "#ffffff" -- filter foreground
+                        , "--nb"
+                        , "#222222" -- normal background
+                        , "--nf"
+                        , "#888888" -- normal foreground
+                        , "--hb"
+                        , "#285577" -- highlighted background
+                        , "--hf"
+                        , "#ffffff" -- highlighted foreground
+                        , "--fn"
+                        , "monospace 12" -- font
+                        , "-W"
+                        , terminalEmulator ++ " -e"
+                        ] -- for this key event a process is spawned in Haskell
+                pure ()
 
+            when (sym == keySymToInt KEY_c) $ do
+                -- the key Events just show up here as ints so you can also match against a raw int
+                wlr_log WLR_INFO "Mod + c pressed closing server"
+                -- for this event we call a Wayland FFI function
+                terminate state
+                pure ()
+            when
+                ( sym == keySymToInt KEY_d || sym == keySymToInt KEY_v || sym == keySymToInt KEY_l
+                )
+                $ do
+                    -- You can also use logical OR
+                    wlr_log WLR_INFO "Mod + d pressed, cycling windows"
+                    result <- cycleWindows state
+                    if result
+                          then wlr_log WLR_INFO "window cycled"
+                          else wlr_log WLR_INFO "Window cycling failed, Only one window"
+                    pure ()
 
 main :: IO ()
 main = runWLHS appConfig

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Config
 import LibTinyWLHS.KeyBinding.KeyBindings
+import Setup
 import WLR.Util.Log
 
 -- Customize your app here, to help I placed the options in the comments
@@ -9,9 +10,14 @@ appConfig :: Config
 appConfig = Config
         { logLevel = WLR_DEBUG -- WLR_INFO | WLR_DEBUG | WLR_SILENT | WLR_ERROR
         , startupApplication = "" -- can be any app that works with wayland, Leave blank for no startup app
+        , onStartup = startApps
         , modKey = ModAlt -- ModAlt | ModCtrl | ModLogo | ModShift
         , terminalEmulator = "kitty" -- I use kitty as my emulator, alacritty is also a popular choice
         }
+    where startApps = do startUpProcess [ ("yambar", [])
+                                        , ("swaybg", ["-i", "./images/haskell.png", "-m", "fill"])
+                                        ]
+
 
 main :: IO ()
 main = runWLHS appConfig


### PR DESCRIPTION
Heya!

I've made a PR that better separates personal configuration from the main code. This is a first step towards allowing different developers to have different configurations by importing this project as a library. It also makes a small effort to make writing configurations a little less intimidating by abstracting away FFI.

This is meant to be a quick and dirty PR and doesn't deal with all problems. For example, the Config.hs file should probably be renamed, but I wanted to gauge interest in this direction before making more extensive changes.