### PR TITLE
change wgb -> swaybg in flake.nix, as is needed by Main.hs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
             yambar
             mako
             bemenu
-            wbg
+            swaybg # formerly, this line was `wbg`
 
             # Build tools
             gcc


### PR DESCRIPTION
This modification to `flake.nix` fixes an error (window immediately crashing) that occurs when trying to run this repository on a baremetal NixOS system on which `swaybg` isn't installed. The error was identical, whether I run things from Sway, Plasma 6, or XMonad. For the error output, see at the bottom. 

This error, which stems from nonexistent swaybg, can also be examined (or "made to disappear") by commenting out line #26 in `src/Main.hs`.

In the new `flake.nix`, I've kept the original entry (`wbg` instead of `swaybg`) as a comment, but this comment could be removed if the intention is to make swaybg replace wbg altogether.

---
The following was the stderr output accompanying the crash that occurs without the above fix:
```
...
00:00:00.007 [INFO] WAYLAND_DISPLAY set to wayland-0
00:00:00.008 [DEBUG] Handler created: 0x0000000040000010
00:00:00.008 [INFO] Starting up applications
00:00:00.008 [INFO] Starting up yambar
00:00:00.008 [INFO] Starting up swaybg
tiny-wlhs: swaybg: createProcess: posix_spawnp: does not exist (No such file or directory)
 err: bar/wayland.c:1068: failed to connect to wayland; no compositor running?
```